### PR TITLE
vanish check immediately following online check

### DIFF
--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/managers/RuleManager.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/managers/RuleManager.java
@@ -84,7 +84,7 @@ public class RuleManager {
         if (isViolatingRules(p)) return true;
 
         //pre rules
-        if (other == null) {
+        if (other == null || !p.canSee(other)) {
             p.sendMessage(Lang.getPrefix() + Lang.get("Player_Not_Online", p));
             return true;
         }
@@ -123,11 +123,6 @@ public class RuleManager {
         //post rules
         if (!other.canSee(p)) {
             p.sendMessage(Lang.getPrefix() + Lang.get("Cannot_trade_while_invisible", p));
-            return true;
-        }
-
-        if (!p.canSee(other)) {
-            p.sendMessage(Lang.getPrefix() + Lang.get("Player_Not_Online", p));
             return true;
         }
 


### PR DESCRIPTION
move the check to see if a player is trying to trade with a player that is vanished to be right after the check if the player is offline. this resolves the issue caused where a player could use /trade <vanished-player> and if the vanished player was in a non-supported gamemode it would tell them that instead of saying they are offline. (also other checks in between but this is the one that made me realize this was an issue)