### PR TITLE
Fix Legacy ItemStacks

### DIFF
--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/extras/external/essentials/DefaultEssentialsPattern.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/extras/external/essentials/DefaultEssentialsPattern.java
@@ -5,7 +5,6 @@ import de.codingair.codingapi.tools.items.XMaterial;
 import de.codingair.tradesystem.spigot.trade.gui.layout.Pattern;
 import de.codingair.tradesystem.spigot.trade.gui.layout.types.impl.basic.*;
 import de.codingair.tradesystem.spigot.trade.gui.layout.utils.IconData;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 public class DefaultEssentialsPattern extends Pattern {
@@ -13,7 +12,7 @@ public class DefaultEssentialsPattern extends Pattern {
     private static final ItemStack BLACK_STAINED = new ItemBuilder(XMaterial.BLACK_STAINED_GLASS_PANE).getItem();
     private static final ItemStack GRAY_STAINED = new ItemBuilder(XMaterial.GRAY_STAINED_GLASS_PANE).getItem();
     private static final ItemStack NUGGET = new ItemBuilder(XMaterial.GOLD_NUGGET).getItem();
-    private static final ItemStack BARRIER = new ItemBuilder(Material.BARRIER).getItem();
+    private static final ItemStack BARRIER = new ItemBuilder(XMaterial.BARRIER).getItem();
     private static final ItemStack STATUS_NONE = new ItemBuilder(XMaterial.LIGHT_GRAY_TERRACOTTA).getItem();
     private static final ItemStack STATUS_READY = new ItemBuilder(XMaterial.LIME_TERRACOTTA).getItem();
     private static final ItemStack STATUS_NOT_READY = new ItemBuilder(XMaterial.RED_TERRACOTTA).getItem();

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/extras/external/vault/DefaultVaultPattern.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/extras/external/vault/DefaultVaultPattern.java
@@ -5,7 +5,6 @@ import de.codingair.codingapi.tools.items.XMaterial;
 import de.codingair.tradesystem.spigot.trade.gui.layout.Pattern;
 import de.codingair.tradesystem.spigot.trade.gui.layout.types.impl.basic.*;
 import de.codingair.tradesystem.spigot.trade.gui.layout.utils.IconData;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 public class DefaultVaultPattern extends Pattern {
@@ -13,7 +12,7 @@ public class DefaultVaultPattern extends Pattern {
     private static final ItemStack BLACK_STAINED = new ItemBuilder(XMaterial.BLACK_STAINED_GLASS_PANE).getItem();
     private static final ItemStack GRAY_STAINED = new ItemBuilder(XMaterial.GRAY_STAINED_GLASS_PANE).getItem();
     private static final ItemStack NUGGET = new ItemBuilder(XMaterial.GOLD_NUGGET).getItem();
-    private static final ItemStack BARRIER = new ItemBuilder(Material.BARRIER).getItem();
+    private static final ItemStack BARRIER = new ItemBuilder(XMaterial.BARRIER).getItem();
     private static final ItemStack STATUS_NONE = new ItemBuilder(XMaterial.LIGHT_GRAY_TERRACOTTA).getItem();
     private static final ItemStack STATUS_READY = new ItemBuilder(XMaterial.LIME_TERRACOTTA).getItem();
     private static final ItemStack STATUS_NOT_READY = new ItemBuilder(XMaterial.RED_TERRACOTTA).getItem();

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/layout/patterns/DefaultExpPattern.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/layout/patterns/DefaultExpPattern.java
@@ -7,7 +7,6 @@ import de.codingair.tradesystem.spigot.trade.gui.layout.types.impl.basic.*;
 import de.codingair.tradesystem.spigot.trade.gui.layout.types.impl.economy.exp.ExpLevelIcon;
 import de.codingair.tradesystem.spigot.trade.gui.layout.types.impl.economy.exp.ShowExpLevelIcon;
 import de.codingair.tradesystem.spigot.trade.gui.layout.utils.IconData;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 public class DefaultExpPattern extends Pattern {
@@ -15,7 +14,7 @@ public class DefaultExpPattern extends Pattern {
     private static final ItemStack BLACK_STAINED = new ItemBuilder(XMaterial.BLACK_STAINED_GLASS_PANE).getItem();
     private static final ItemStack GRAY_STAINED = new ItemBuilder(XMaterial.GRAY_STAINED_GLASS_PANE).getItem();
     private static final ItemStack NUGGET = new ItemBuilder(XMaterial.GOLD_NUGGET).getItem();
-    private static final ItemStack BARRIER = new ItemBuilder(Material.BARRIER).getItem();
+    private static final ItemStack BARRIER = new ItemBuilder(XMaterial.BARRIER).getItem();
     private static final ItemStack STATUS_NONE = new ItemBuilder(XMaterial.LIGHT_GRAY_TERRACOTTA).getItem();
     private static final ItemStack STATUS_READY = new ItemBuilder(XMaterial.LIME_TERRACOTTA).getItem();
     private static final ItemStack STATUS_NOT_READY = new ItemBuilder(XMaterial.RED_TERRACOTTA).getItem();

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/layout/patterns/DefaultPattern.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/layout/patterns/DefaultPattern.java
@@ -5,14 +5,13 @@ import de.codingair.codingapi.tools.items.XMaterial;
 import de.codingair.tradesystem.spigot.trade.gui.layout.Pattern;
 import de.codingair.tradesystem.spigot.trade.gui.layout.types.impl.basic.*;
 import de.codingair.tradesystem.spigot.trade.gui.layout.utils.IconData;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 public class DefaultPattern extends Pattern {
     public static final String NAME = "Standard";
     private static final ItemStack BLACK_STAINED = new ItemBuilder(XMaterial.BLACK_STAINED_GLASS_PANE).getItem();
     private static final ItemStack GRAY_STAINED = new ItemBuilder(XMaterial.GRAY_STAINED_GLASS_PANE).getItem();
-    private static final ItemStack BARRIER = new ItemBuilder(Material.BARRIER).getItem();
+    private static final ItemStack BARRIER = new ItemBuilder(XMaterial.BARRIER).getItem();
     private static final ItemStack STATUS_NONE = new ItemBuilder(XMaterial.LIGHT_GRAY_TERRACOTTA).getItem();
     private static final ItemStack STATUS_READY = new ItemBuilder(XMaterial.LIME_TERRACOTTA).getItem();
     private static final ItemStack STATUS_NOT_READY = new ItemBuilder(XMaterial.RED_TERRACOTTA).getItem();

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/layout/types/impl/cosmetics/PlayerHeadUtils.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/layout/types/impl/cosmetics/PlayerHeadUtils.java
@@ -1,8 +1,8 @@
 package de.codingair.tradesystem.spigot.trade.gui.layout.types.impl.cosmetics;
 
 import de.codingair.codingapi.tools.items.ItemBuilder;
+import de.codingair.codingapi.tools.items.XMaterial;
 import de.codingair.tradesystem.spigot.TradeSystem;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,7 +14,7 @@ public class PlayerHeadUtils {
     }
 
     public static void applyPlayerHead(@NotNull ItemBuilder builder, @Nullable Player player, @NotNull String name) {
-        if (builder.getType() == Material.PLAYER_HEAD) {
+        if (builder.getType() == XMaterial.PLAYER_HEAD.parseMaterial()) {
             if (player != null) builder.setSkullId(player);
             else builder.setSkullId(TradeSystem.proxy().getSkin(name));
         }


### PR DESCRIPTION
Fixing legacy versions using TradeSystem by using `XMaterial` instead of `Material`
Needs to be tested but GUI seems to open fine.

Closes #457