### PR TITLE
Add config option to only use display name for items

### DIFF
--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/PlayerTradeResult.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/PlayerTradeResult.java
@@ -1,6 +1,7 @@
 package de.codingair.tradesystem.spigot.trade;
 
 import de.codingair.codingapi.utils.ChatColor;
+import de.codingair.tradesystem.spigot.TradeSystem;
 import de.codingair.tradesystem.spigot.trade.gui.layout.types.impl.economy.EconomyIcon;
 import de.codingair.tradesystem.spigot.trade.gui.layout.utils.Perspective;
 import de.codingair.tradesystem.spigot.utils.Lang;
@@ -38,7 +39,8 @@ public class PlayerTradeResult extends TradeResult {
                 ItemMeta meta = item.getItemMeta();
                 assert meta != null;
 
-                if (meta.hasDisplayName()) return formatName(item.getType().name()) + " (" + ChatColor.stripColor(meta.getDisplayName()) + ")";
+                if (meta.hasDisplayName())
+                    return TradeSystem.handler().isOnlyDisplayNameInMessage() ? meta.getDisplayName() : formatName(item.getType().name()) + " (" + ChatColor.stripColor(meta.getDisplayName()) + ")";
             }
 
             return formatName(item.getType().name());

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/TradeHandler.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/TradeHandler.java
@@ -105,10 +105,10 @@ public class TradeHandler {
         this.tradeBoth = config.getBoolean("TradeSystem.Trade_Both", true);
         this.inputGUI = InputGUI.getByName(config.getString("TradeSystem.Input_GUI", "SIGN"));
         this.dropItems = config.getBoolean("TradeSystem.Trade_Drop_Items", true);
-        this.onlyDisplayNameInMessage = config.getBoolean("TradeSystem.Only_DisplayName_in_Message", false);
 
         this.tradeReportItems = config.getBoolean("TradeSystem.Trade_Finish_Report.Items", true);
         this.tradeReportEconomy = config.getBoolean("TradeSystem.Trade_Finish_Report.Economy", true);
+        this.onlyDisplayNameInMessage = config.getBoolean("TradeSystem.Trade_Finish_Report.Only_DisplayName_in_Message", false);
 
         if (config.getBoolean("TradeSystem.Trade_Countdown.Enabled", true)) {
             countdownRepetitions = config.getInt("TradeSystem.Trade_Countdown.Repetitions");

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/TradeHandler.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/TradeHandler.java
@@ -66,6 +66,7 @@ public class TradeHandler {
     private InputGUI inputGUI = InputGUI.SIGN;
     private boolean tradeBoth = true;
     private boolean dropItems = true;
+    private boolean onlyDisplayNameInMessage = false;
 
     private SoundData soundStarted = null;
     private SoundData soundFinish = null;
@@ -104,6 +105,7 @@ public class TradeHandler {
         this.tradeBoth = config.getBoolean("TradeSystem.Trade_Both", true);
         this.inputGUI = InputGUI.getByName(config.getString("TradeSystem.Input_GUI", "SIGN"));
         this.dropItems = config.getBoolean("TradeSystem.Trade_Drop_Items", true);
+        this.onlyDisplayNameInMessage = config.getBoolean("TradeSystem.Only_DisplayName_in_Message", false);
 
         this.tradeReportItems = config.getBoolean("TradeSystem.Trade_Finish_Report.Items", true);
         this.tradeReportEconomy = config.getBoolean("TradeSystem.Trade_Finish_Report.Economy", true);
@@ -432,6 +434,10 @@ public class TradeHandler {
 
     public void setDropItems(boolean dropItems) {
         this.dropItems = dropItems;
+    }
+
+    public boolean isOnlyDisplayNameInMessage() {
+        return onlyDisplayNameInMessage;
     }
 
     public boolean isOffline(Player player) {

--- a/TradeSystem-Spigot/src/main/resources/Config.yml
+++ b/TradeSystem-Spigot/src/main/resources/Config.yml
@@ -18,6 +18,9 @@ TradeSystem:
   # This is highly recommended to be enabled. Otherwise, players can easily scam others. Only disable this setting if you know your users.
   Revoke_Ready_State_on_Offer_Change: true
 
+  # Whether to only display an items display name rather than item type & display name in chat when the trade is successful.
+  Only_DisplayName_in_Message: false
+
   Allowed_GameModes:
   - SURVIVAL
   Blocked_Worlds:

--- a/TradeSystem-Spigot/src/main/resources/Config.yml
+++ b/TradeSystem-Spigot/src/main/resources/Config.yml
@@ -18,9 +18,6 @@ TradeSystem:
   # This is highly recommended to be enabled. Otherwise, players can easily scam others. Only disable this setting if you know your users.
   Revoke_Ready_State_on_Offer_Change: true
 
-  # Whether to only display an items display name rather than item type & display name in chat when the trade is successful.
-  Only_DisplayName_in_Message: false
-
   Allowed_GameModes:
   - SURVIVAL
   Blocked_Worlds:
@@ -68,6 +65,9 @@ TradeSystem:
   Trade_Finish_Report:
     Items: true
     Economy: true
+
+    # Whether to only display an items display name rather than item type & display name in chat when the trade is successful.
+    Only_DisplayName_in_Message: false
 
   Action_To_Cancel:
     Player_get_damaged: true


### PR DESCRIPTION
I am the lead developer on a server that uses bread as the base item for all textures we have, with the help of custom model data we apply custom textures to bread. Therefore the items display name is the only name we want to display whenever a trade is completed.

I have added a config option and defaulted it to false for this behavior. It would be greatly appreciated if this could be merged in and be available in future releases!

Closes: #448