### PR TITLE
No item consume when trading.

### DIFF
--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/listeners/TradeListener.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/listeners/TradeListener.java
@@ -12,6 +12,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.jetbrains.annotations.NotNull;
@@ -90,4 +91,14 @@ public class TradeListener implements Listener, ChatButtonListener {
         }
     }
 
+    @EventHandler(ignoreCancelled = true)
+    public void onItemConsume(PlayerItemConsumeEvent event) {
+        Player player = event.getPlayer();
+        Trade trade = TradeSystem.handler().getTrade(player);
+
+        if(trade == null)
+            return;
+
+        event.setCancelled(true);
+    }
 }


### PR DESCRIPTION
Send a player a trade -> start eating a golden apple or drinking a potion -> another player accepts the trade -> we have a trade window open -> while eating the apple continues, even though we're sort of trading.

Fixes unplanned eating of items during a trade.