### PR TITLE
Permissions for add money and items

### DIFF
--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/TradeGUIListener.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/TradeGUIListener.java
@@ -64,6 +64,12 @@ public class TradeGUIListener implements Listener {
             Trade trade = TradeSystem.handler().getTrade(player);
 
             if (trade != null && trade.inMainGUI(player)) {
+                if(!player.hasPermission("tradesystem.trade.item")) {
+                    Lang.send(player, "No_Permissions");
+                    e.setCancelled(true);
+                    return;
+                }
+
                 // Cancelling the drag event resets the cursor in a later tick.
                 // Therefore, simply remove all new items added during this event.
                 e.setCancelled(false);
@@ -87,6 +93,12 @@ public class TradeGUIListener implements Listener {
             if (trade != null && trade.inMainGUI(player)) {
                 // allow blocking by other plugins
                 if (e.isCancelled()) return;
+
+                if(!player.hasPermission("tradesystem.trade.item")) {
+                    Lang.send(player, "No_Permissions");
+                    e.setCancelled(true);
+                    return;
+                }
 
                 // cancel everything and project changes later
                 e.setCancelled(true);

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/TradeGUIListener.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/TradeGUIListener.java
@@ -9,6 +9,7 @@ import de.codingair.tradesystem.spigot.trade.Trade;
 import de.codingair.tradesystem.spigot.trade.gui.layout.shulker.ShulkerPeekGUI;
 import de.codingair.tradesystem.spigot.trade.gui.layout.utils.Perspective;
 import de.codingair.tradesystem.spigot.utils.Lang;
+import de.codingair.tradesystem.spigot.utils.Permissions;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -64,7 +65,7 @@ public class TradeGUIListener implements Listener {
             Trade trade = TradeSystem.handler().getTrade(player);
 
             if (trade != null && trade.inMainGUI(player)) {
-                if(!player.hasPermission("tradesystem.trade.item")) {
+                if(!player.hasPermission(Permissions.PERMISSION_TRADE_ITEM)) {
                     Lang.send(player, "No_Permissions");
                     e.setCancelled(true);
                     return;
@@ -94,7 +95,7 @@ public class TradeGUIListener implements Listener {
                 // allow blocking by other plugins
                 if (e.isCancelled()) return;
 
-                if(!player.hasPermission("tradesystem.trade.item")) {
+                if(!player.hasPermission(Permissions.PERMISSION_TRADE_ITEM)) {
                     Lang.send(player, "No_Permissions");
                     e.setCancelled(true);
                     return;

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/layout/types/impl/economy/EconomyIcon.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/layout/types/impl/economy/EconomyIcon.java
@@ -13,6 +13,7 @@ import de.codingair.tradesystem.spigot.trade.gui.layout.types.feedback.FinishRes
 import de.codingair.tradesystem.spigot.trade.gui.layout.types.feedback.IconResult;
 import de.codingair.tradesystem.spigot.trade.gui.layout.utils.Perspective;
 import de.codingair.tradesystem.spigot.utils.Lang;
+import de.codingair.tradesystem.spigot.utils.Permissions;
 import org.bukkit.Bukkit;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -53,7 +54,7 @@ public abstract class EconomyIcon<T extends Transition.Consumer<BigDecimal> & Tr
         Player player = trade.getPlayer(perspective);
         if (player == null) return false;
 
-        if(!player.hasPermission("tradesystem.trade.money")) {
+        if(!player.hasPermission(Permissions.PERMISSION_TRADE_MONEY)) {
             Lang.send(player, "No_Permissions");
             return false;
         }

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/layout/types/impl/economy/EconomyIcon.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/gui/layout/types/impl/economy/EconomyIcon.java
@@ -53,6 +53,11 @@ public abstract class EconomyIcon<T extends Transition.Consumer<BigDecimal> & Tr
         Player player = trade.getPlayer(perspective);
         if (player == null) return false;
 
+        if(!player.hasPermission("tradesystem.trade.money")) {
+            Lang.send(player, "No_Permissions");
+            return false;
+        }
+
         if (getBalance(player).signum() <= 0) {
             Lang.send(player, "Balance_limit_reached");
             return false;

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/Permissions.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/Permissions.java
@@ -10,6 +10,8 @@ public class Permissions {
     public static final String PERMISSION_LOG = "TradeSystem.Log";
     public static String PERMISSION = "TradeSystem.Trade";
     public static String PERMISSION_INITIATE = "TradeSystem.Trade.Initiate";
+    public static String PERMISSION_TRADE_MONEY = "TradeSystem.Trade.Money";
+    public static String PERMISSION_TRADE_ITEM = "TradeSystem.Trade.Item";
 
     private static final String[] PLUGINS = {
             "LuckPerms", "PermissionsEx", "GroupManager", "Vault", "bPermissions", "PermissionsBukkit",

--- a/TradeSystem-Spigot/src/main/resources/plugin.yml
+++ b/TradeSystem-Spigot/src/main/resources/plugin.yml
@@ -17,6 +17,10 @@ permissions:
     default: op
   tradesystem.trade:
     default: op
+  tradesystem.trade.money:
+    default: op
+  tradesystem.trade.item:
+    default: op
   tradesystem.trade.initiate:
     default: op
   tradesystem.*:
@@ -25,4 +29,6 @@ permissions:
       tradesystem.modify: true
       tradesystem.log: true
       tradesystem.trade: true
+      tradesystem.trade.item: true
+      tradesystem.trade.money: true
       tradesystem.trade.initiate: true


### PR DESCRIPTION
Added permissions for trades with currency and items.

Where can it be useful? For example, if someone needs to buy the rights to be able to transfer money through trades, this could be bypassed.

If someone doesn't want to allow transferring items, I honestly can't think of why, but why not?