### PR TITLE
Update TradeSystem to 1.21.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.codingair</groupId>
     <artifactId>TradeSystem</artifactId>
-    <version>2.6.2_Hotfix-1</version>
+    <version>2.6.3</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>com.github.CodingAir</groupId>
                 <artifactId>CodingAPI</artifactId>
-                <version>1.89</version>
+                <version>1.90</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Requires CodingAPI from https://github.com/erikzimmermann/CodingAPI/tree/version/1.21.3 to be published first.